### PR TITLE
Two small changes (tested it for sway)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The tool relies on the `def listen` feature of EWW to stream updates as needed. 
 Example Eww Configuration:
 
 ```
-(deflisten SPACES :initial '{"":0,"workspaces":[]}' "~/.config/eww/scripts/eww-ws")
+(deflisten SPACES :initial '{"active":0,"workspaces":[]}' "~/.config/eww/scripts/eww-ws")
 
 (defwidget ws []
   (box :class "workspaces"

--- a/README.md
+++ b/README.md
@@ -10,8 +10,7 @@ The tool relies on the `def listen` feature of EWW to stream updates as needed. 
 Example Eww Configuration:
 
 ```
-(deflisten SPACES :initial "{\"active\":0, \"workspaces\":[]}"
-  `~/.config/eww/scripts/eww-ws`)
+(deflisten SPACES :initial '{"":0,"workspaces":[]}' "~/.config/eww/scripts/eww-ws")
 
 (defwidget ws []
   (box :class "workspaces"

--- a/sway.go
+++ b/sway.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"os"
 
@@ -69,7 +68,6 @@ func (s Sway) listen() error {
 	h := WSEHandler{
 		s: s,
 	}
-	fmt.Println("things")
 	return sway.Subscribe(ctx, h, sway.EventTypeWorkspace)
 }
 


### PR DESCRIPTION
- update the example, it had backticks so was throwing an error, also single quotes around the initial value so you don't have to escape. 
- removed the "things" sting was being shown at the end of the json object (caused error when parsing)