### PR TITLE
remove hyprland scratchpad workspace

### DIFF
--- a/hyperland.go
+++ b/hyperland.go
@@ -150,7 +150,15 @@ func (h Hyperland) getWorkspaces() ([]Workspace, error) {
 	if err != nil {
 		return nil, err
 	}
-	var st SortWorkspaces = ws
+
+	wsNormal := []Workspace{}
+	for _, w := range ws {
+		if w.Name != "special:magic" {
+			wsNormal = append(wsNormal, w)
+		}
+	}
+
+	var st SortWorkspaces = wsNormal
 	sort.Sort(st)
 
 	return st, nil


### PR DESCRIPTION
This removes the scratchpad or magic workspace from showing up as "special:magic" in the workspaces widget.